### PR TITLE
Modification of ndigit to be able to run HRMS

### DIFF
--- a/R/metaMSsettings.R
+++ b/R/metaMSsettings.R
@@ -23,6 +23,7 @@ metaMSsettings <-
                  ## chromatography
                  DBconstruction = representation(
                      minfeat = "numeric",                     # both
+                     ndigits = "numeric",                     # both
                      rttol = "numeric",                       # LC
                      mztol = "numeric",                       # LC
                      minintens = "numeric",                   # LC

--- a/R/msp.R
+++ b/R/msp.R
@@ -250,12 +250,13 @@ read.msp <- function(file, only.org = FALSE,
 ## individual arguments (and has precedence over these, too).
 
 to.msp <- function(object, file = NULL,
-                   settings = NULL, ndigit = 0, minfeat, minintens,
+                   settings = NULL, minfeat, minintens,
                    intensity = c("maxo", "into"), secs2mins = TRUE) {
   if (!is.null(settings)) {
     intensity <- settings$intensityMeasure
     minfeat <- settings$minfeat
     minintens <- settings$minintens
+    ndigit <- settings$ndigits
   } else {
     intensity <- match.arg(intensity)
   }


### PR DESCRIPTION
Just few modifications to be able to choose how many digits you want according to your acquisition.
Effectively if you made HRMS you would like to have some digits !

Be careful, according to the metaMS processus, you can "loose" some pseudospectra if you increase the number of digits : if you increase the number of digits, pseudospectra will be more different between samples and not keep for the result. In contrary if you decrease the number of digits, peaks in pseudospectrum will be merged together and you will have more chances to obtain more or less the same pseudospectrum between samples.

By default, it can be set to 0 in your parameter (*have to add it maybe?*)