### PR TITLE
avoid importing BiocGenerics::data

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 ## load specific functions from tools and robustbase
-import(BiocGenerics, except=relist)
+import(BiocGenerics, except=c("relist", "data"))
 import(methods)
 import(xcms, except=plot)
 import(CAMERA)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,9 +1,8 @@
 ## load specific functions from tools and robustbase
-import(BiocGenerics, except=c("relist", "data"))
+import(BiocGenerics, except=relist)
 import(methods)
 import(xcms, except=plot)
 import(CAMERA)
-import(utils)
 importFrom(tools, file_ext, list_files_with_exts, file_path_sans_ext)
 importFrom(robustbase, lmrob)
 importFrom(Matrix, Matrix)


### PR DESCRIPTION
Recently `BiocGenerics::data` has been added as a new generic:
https://github.com/Bioconductor/BiocGenerics/commit/93a0f55d0280cdef46603c677a0a955ba966bfd6

This PR fixes the following warning by avoid importing `data` from BiocGenerics:

``` r
> devtools::load_all(".")
ℹ Loading metaMS
Warning message:
replacing previous import ‘BiocGenerics::data’ by ‘utils::data’ when loading ‘metaMS’ 
```

CC @hpages